### PR TITLE
[CMakeList の変更] c++11 のコンパイルオプションを有効化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(chibi23_a)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+# Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)


### PR DESCRIPTION
c++ 11 をコンパイルできるように `CMakeList` を変更しました

参考：https://answers.ros.org/question/216842/ros-using-c-11-how-to-use-with-catkin/